### PR TITLE
Use timerTime instead of elapsedTime for pace calculation

### DIFF
--- a/source/KiloschmenzerFitContributions.mc
+++ b/source/KiloschmenzerFitContributions.mc
@@ -69,9 +69,9 @@ class KschmFitContributor {
     //! Update data and fields
     //! @param sensor The ANT channel and data
     public function compute(info as Activity.Info) as Void {
-        if (_timerRunning && info.elapsedDistance != null && info.elapsedTime != null && info.totalAscent != null) {
+        if (_timerRunning && info.elapsedDistance != null && info.timerTime != null && info.totalAscent != null) {
             // Update lap/session data and record counts
-            _sessionElapsedMs = info.elapsedTime;
+            _sessionElapsedMs = info.timerTime;
             _lapElapsedMs = _sessionElapsedMs - _sumPreviousLapsMs;
             _sessionDistance = info.elapsedDistance;
             _lapDistance = _sessionDistance - _sumPreviousLapsDistance;
@@ -139,7 +139,7 @@ class KschmFitContributor {
             return;
         }
 
-        _sumPreviousLapsMs = info.elapsedTime;
+        _sumPreviousLapsMs = info.timerTime;
         _sumPreviousLapsVert = info.totalAscent;
         _sumPreviousLapsDistance = info.elapsedDistance;
         _lapElapsedMs = 0;


### PR DESCRIPTION
Tyler reported pace values going way up after pausing an activity and resuming. This was caused by using Activity.Info.elapsedTime which continues incrementing, even when the activity is paused. We should've been using timerTime which stops running during pauses.